### PR TITLE
README: fix error in zkclient installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Create a zkclient directory and copy the config file in place and then edit the
 config file.
 ```bash
 $ mkdir ~/.zkclient
-$ cp $GOPATH/src/github.com/companyzero/zkc/zkserver/zkclient.conf ~/.zkclient/
+$ cp $GOPATH/src/github.com/companyzero/zkc/zkclient/zkclient.conf ~/.zkclient/
 $ vi ~/.zkclient/zkclient.conf
 ```
 


### PR DESCRIPTION
This PR fixes a slight error in the installation instructions for `zkclient`. The path in the README as is, is off: is points to the `zkserver` directory when it should actually be the `zkclient` directory. 