### PR TITLE
rework parsing of myserver.ini

### DIFF
--- a/zkclient/zkclient.go
+++ b/zkclient/zkclient.go
@@ -1680,7 +1680,7 @@ func _main() error {
 		}
 	}
 
-	if foundClientIdentity == false {
+	if !foundClientIdentity {
 		// obtain local identity info
 		usr, err = user.Current()
 		if err != nil {
@@ -1735,7 +1735,7 @@ func _main() error {
 	// setup high and low prio message channels
 	z.scheduler()
 
-	if foundClientIdentity == false {
+	if !foundClientIdentity {
 		// create and focus on welcome window
 		ww := &welcomeWindow{
 			name: usr.Name,

--- a/zkclient/zkclient.go
+++ b/zkclient/zkclient.go
@@ -1644,6 +1644,9 @@ func _main() error {
 
 	// see if we have a myserver.ini
 	var server *inidb.INIDB
+	var foundServerIdentity bool
+	var foundClientIdentity bool
+	var usr *user.User
 
 	for tries := 0; tries < 3; tries++ {
 		server, err = inidb.New(filename, false, 10)
@@ -1658,6 +1661,7 @@ func _main() error {
 			continue
 		}
 		if err == nil {
+			foundServerIdentity = true
 			// obtain all entries from ini
 			err = z.parseMyServer(server)
 			if err != nil {
@@ -1666,6 +1670,28 @@ func _main() error {
 			}
 		}
 		break
+	}
+
+	// server and client identities are stored together
+	if foundServerIdentity {
+		err = z.parseMyIdentity(server)
+		if err == nil {
+			foundClientIdentity = true
+		}
+	}
+
+	if foundClientIdentity == false {
+		// obtain local identity info
+		usr, err = user.Current()
+		if err != nil {
+			return err
+		}
+
+		z.id, err = zkidentity.New(usr.Name, usr.Username)
+		if err != nil {
+			// really can't happen
+			return fmt.Errorf("could not create new identity")
+		}
 	}
 
 	// initialize terminal
@@ -1694,25 +1720,6 @@ func _main() error {
 	}
 	z.ttkKAW = ttk.NewWindow(z.kaw)
 
-	var newIdentity bool
-	var usr *user.User
-	err = z.parseMyIdentity(server)
-	if err != nil {
-		// obtain local identity info
-		usr, err = user.Current()
-		if err != nil {
-			return err
-		}
-
-		// create new identity
-		newIdentity = true
-		z.id, err = zkidentity.New(usr.Name, usr.Username)
-		if err != nil {
-			// really can't happen
-			return fmt.Errorf("could not create new identity")
-		}
-	}
-
 	// bootstrap all known
 	err = z.loadIdentities()
 	if err != nil {
@@ -1728,7 +1735,7 @@ func _main() error {
 	// setup high and low prio message channels
 	z.scheduler()
 
-	if newIdentity {
+	if foundClientIdentity == false {
 		// create and focus on welcome window
 		ww := &welcomeWindow{
 			name: usr.Name,


### PR DESCRIPTION
rework the case where myserver.ini exists but doesn't have a client identity yet, so that we don't explode if myserver.ini doesn't exist.

tests performed:

case 1: myserver.ini exists, has server's id, client's id: connects, works
case 2: myserver.ini exists, has server's id only: "zkc detected that this is the first time it is run." dialog
case 3: myserver.ini exists, has client's id only: "could not parse myserver: could not obtain server record"
case 4: myserver.ini exists, has client's id, server's address: "could not parse myserver: could not obtain serveridentity record"
case 5: myserver.ini exists, is empty: "could not parse myserver: could not obtain server record"
case 6: myserver.ini doesn't exist: "zkc detected that this is the first time it is run." (XXX was crashing before)
case 7: myserver (the directory) doesn't exist: "zkc detected that this is the first time it is run."