### PR TITLE
fix the population of ngc.Members in gcKick()

### DIFF
--- a/zkclient/groupchat.go
+++ b/zkclient/groupchat.go
@@ -271,7 +271,7 @@ func (z *ZKC) gcKick(args []string) error {
 	ngc.Members = make([][zkidentity.IdentitySize]byte, 0, len(gc.Members))
 	// warn if user is not in kicklist but do it anyway
 	found = false
-	for _,m := range(gc.Members) {
+	for _, m := range gc.Members {
 		if bytes.Equal(m[:], id.Identity[:]) == false {
 			ngc.Members = append(ngc.Members, m)
 		} else {

--- a/zkclient/groupchat.go
+++ b/zkclient/groupchat.go
@@ -268,19 +268,17 @@ func (z *ZKC) gcKick(args []string) error {
 	}
 	ngc.Generation++
 
+	ngc.Members = make([][zkidentity.IdentitySize]byte, 0, len(gc.Members))
 	// warn if user is not in kicklist but do it anyway
 	found = false
-	for i := 1; i < len(gc.Members); i++ {
-		if !bytes.Equal(gc.Members[i][:], id.Identity[:]) {
-			continue
+	for _,m := range(gc.Members) {
+		if bytes.Equal(m[:], id.Identity[:]) == false {
+			ngc.Members = append(ngc.Members, m)
+		} else {
+			found = true
 		}
-
-		// remove from member list
-		ngc.Members = append(gc.Members[:i:i], gc.Members[i+1:]...)
-		found = true
-		break
 	}
-	if !found {
+	if found == false {
 		z.PrintfT(-1, "WARNING: %v not part of %v, sending kick "+
 			"message anyway", args[3], args[2])
 	}


### PR DESCRIPTION
fix the loop populating the members list of a new group chat so
that, if the user being kicked is not found, the resulting members
list is identical to the old one, which is the expected behaviour.
this fixes https://github.com/companyzero/zkc/issues/30.