### PR TITLE
hide a window before closing it

### DIFF
--- a/zkclient/mainwindow.go
+++ b/zkclient/mainwindow.go
@@ -613,6 +613,7 @@ func (mw *mainWindow) action(cmd string) error {
 
 		// delete conversation from list
 		i := mw.zkc.active
+		mw.zkc.conversation[i].console.Visibility(ttk.VisibilityHide)
 		mw.zkc.conversation = append(mw.zkc.conversation[:i:i],
 			mw.zkc.conversation[i+1:]...)
 		mw.zkc.focus(0)


### PR DESCRIPTION
ensure a window being closed is hidden before focus is shifted to
the main window, or we risk leaving lines from the closed window on
the screen. this fixes #46.