### PR TITLE
introduce "day changed to" in conversations

### DIFF
--- a/zkclient/zkclient.go
+++ b/zkclient/zkclient.go
@@ -82,9 +82,9 @@ func (z *ZKC) calculateStatus() string {
 }
 
 func differentDay(x, y time.Time) bool {
-	return x.Day()   != y.Day() ||
-	       x.Month() != y.Month() ||
-	       x.Year()  != y.Year()
+	return x.Day() != y.Day() ||
+		x.Month() != y.Month() ||
+		x.Year() != y.Year()
 }
 
 // updateTS updates the timestamp of a conversation. Lock must be held.


### PR DESCRIPTION
keep track of when messages were last received for a given
conversation, and inform the user about messages spanning day
boundaries ("day changed to"). this closes #55.