### PR TITLE
Adding dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ $ go version
 
 ```bash
 $ go get -u github.com/golang/dep/cmd/dep
+$ go get -u golang.org/x/sys/unix
 $ mkdir -p $GOPATH/src/github.com/companyzero/
 $ cd $GOPATH/src/github.com/companyzero/
 $ git clone https://github.com/companyzero/zkc


### PR DESCRIPTION
 go get -u golang.org/x/sys/unix

My clean install of Ubuntu didn't have this