### PR TITLE
Don't abort loading identities finds a dup nick.

### DIFF
--- a/zkclient/addressbook.go
+++ b/zkclient/addressbook.go
@@ -120,7 +120,7 @@ func (z *ZKC) loadIdentities() error {
 		err = z.addressBookAdd(idDisk)
 		if err != nil {
 			z.PrintfT(0, "unable to add to address book: %v", err)
-			return err
+			continue
 		}
 	}
 


### PR DESCRIPTION
Not sure when this crept in but a duplicate nick is not a permanent
failure. It simply prepends an _ to the nick to indicate that there is a
duplicate. Aborting causes mayhem as incoming messages don't have nicks
associated and the user sees identities instead,