### PR TITLE
Allow and use "no attribute" colors in config

### DIFF
--- a/zkclient/settings.go
+++ b/zkclient/settings.go
@@ -51,6 +51,8 @@ type Settings struct {
 func textToColor(in string) (int, error) {
 	var c int
 	switch strings.ToLower(in) {
+	case "na":
+		c = ttk.AttrNA
 	case "black":
 		c = ttk.ColorBlack
 	case "red":

--- a/zkclient/zkclient.conf.go
+++ b/zkclient/zkclient.conf.go
@@ -37,12 +37,12 @@ debug = no
 # requires debug = yes
 profiler = 127.0.0.1:6061
 
-# Valid ui colors: black, red, green, yellow, blue, magenta, cyan and white
+# Valid ui colors: na, black, red, green, yellow, blue, magenta, cyan and white
 # Valid atttributes are: none, underline and bold
 # format is: attribute:foreground:background
 [ui]
-nickcolor = bold:white:black
-gcothercolor = bold:green:black
-pmothercolor = bold:cyan:black
+nickcolor = bold:na:na
+gcothercolor = bold:green:na
+pmothercolor = bold:cyan:na
 `
 )


### PR DESCRIPTION
Results look better on terminals that have different colors for black
and background.