### PR TITLE
Auto-open configured group windows at startup

### DIFF
--- a/zkclient/settings.go
+++ b/zkclient/settings.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 
 	"github.com/companyzero/ttk"
@@ -46,6 +47,9 @@ type Settings struct {
 	NickColor string
 	GcColor   string
 	PmColor   string
+
+	// auto-open groups
+	OpenGroups []string
 }
 
 func textToColor(in string) (int, error) {
@@ -286,6 +290,24 @@ func ObtainSettings() (*Settings, error) {
 		}
 		s.PmColor = color
 	}
+
+	groups := cfg.Section("groups")
+	openGroups := make([]string, len(groups))
+	for window, group := range groups {
+		n, err := strconv.Atoi(window)
+		if err != nil {
+			return nil, fmt.Errorf("groups: %q: %v", group, err)
+		}
+		if n <= 0 || n > len(groups)+1 {
+			return nil, fmt.Errorf("groups: %q: window %d unusable", group, n)
+		}
+		g := &openGroups[n-1]
+		if *g != "" {
+			return nil, fmt.Errorf("groups: %q: window %d in-use by %q", group, n, *g)
+		}
+		*g = group
+	}
+	s.OpenGroups = openGroups
 
 	return &s, nil
 }

--- a/zkclient/zkclient.conf.go
+++ b/zkclient/zkclient.conf.go
@@ -44,5 +44,12 @@ profiler = 127.0.0.1:6061
 nickcolor = bold:na:na
 gcothercolor = bold:green:na
 pmothercolor = bold:cyan:na
+
+# Joined groups can be auto-opened in a specified order.
+# Each key describes the window index, and the value must be the group name.
+# Indexes begin at 1 due to index 0 being reserved for the console window.
+[groups]
+# 1 = firstgroup
+# 2 = secondgroup
 `
 )

--- a/zkclient/zkclient.go
+++ b/zkclient/zkclient.go
@@ -975,14 +975,7 @@ func (z *ZKC) goOnline() (*rpc.Welcome, error) {
 		return nil, err
 	}
 
-	welcome, err := z.welcomePhase(kx)
-	if err != nil {
-		return nil, err
-	}
-
-	go z.handleRPC()
-
-	return welcome, nil
+	return z.welcomePhase(kx)
 }
 
 //
@@ -1001,6 +994,15 @@ func (z *ZKC) goOnlineAndPrint() error {
 	default:
 		err = z.welcomeUser(welcome)
 	}
+
+	for _, group := range z.settings.OpenGroups {
+		_, _, err = z.groupConversation(group)
+		if err != nil {
+			z.PrintfT(0, "Failed to open group window %q", group)
+		}
+	}
+
+	go z.handleRPC()
 
 	return err
 }

--- a/zkclient/zkclient.go
+++ b/zkclient/zkclient.go
@@ -994,6 +994,9 @@ func (z *ZKC) goOnlineAndPrint() error {
 	default:
 		err = z.welcomeUser(welcome)
 	}
+	if err != nil {
+		return err
+	}
 
 	for _, group := range z.settings.OpenGroups {
 		_, _, err = z.groupConversation(group)
@@ -1004,7 +1007,7 @@ func (z *ZKC) goOnlineAndPrint() error {
 
 	go z.handleRPC()
 
-	return err
+	return nil
 }
 
 func (z *ZKC) goOnlineRetry() {


### PR DESCRIPTION
A [groups] section is added to the zkclient config file and must
specify 'index = name' pairs for each group name and the window index.

This is handy to keep groupchat windows in a common location across
client restarts.
